### PR TITLE
Make Autonomous Selection an Optional

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -66,7 +66,7 @@ public class Robot extends TimedRobot {
   public void autonomousInit() {
     // Get the selected autonomous, and schedule it
     autonomousCommand = robotContainer.getAutonomousCommand();
-    autonomousCommand.ifPresent((command) -> command.schedule());
+    autonomousCommand.ifPresent(Command::schedule);
   }
 
   /** This function is called periodically during autonomous. */
@@ -76,7 +76,7 @@ public class Robot extends TimedRobot {
   @Override
   public void teleopInit() {
     // Cancel the autonomous command when teleop starts running.
-    autonomousCommand.ifPresent((command) -> command.cancel());
+    autonomousCommand.ifPresent(Command::cancel);
   }
 
   /** This function is called periodically during operator control. */

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -64,9 +64,8 @@ public class Robot extends TimedRobot {
   /** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
   @Override
   public void autonomousInit() {
+    // Get the selected autonomous, and schedule it
     autonomousCommand = robotContainer.getAutonomousCommand();
-
-    // Schedule the autonomous command
     autonomousCommand.ifPresent((command) -> command.schedule());
   }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -64,7 +64,7 @@ public class Robot extends TimedRobot {
   /** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
   @Override
   public void autonomousInit() {
-    // Get the selected autonomous, and schedule it
+    // If we have an autonomous command selected, schedule it to be ran.
     autonomousCommand = robotContainer.getAutonomousCommand();
     autonomousCommand.ifPresent(Command::schedule);
   }
@@ -75,7 +75,7 @@ public class Robot extends TimedRobot {
 
   @Override
   public void teleopInit() {
-    // Cancel the autonomous command when teleop starts running.
+    // If we were running an autonomous command, cancel it when teleop starts.
     autonomousCommand.ifPresent(Command::cancel);
   }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -17,7 +17,7 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
  * project.
  */
 public class Robot extends TimedRobot {
-  private Optional<Command> autonomousCommand;
+  private Optional<Command> autonomousCommand = Optional.empty();
 
   private RobotContainer robotContainer;
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -17,7 +17,7 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
  * project.
  */
 public class Robot extends TimedRobot {
-  private Command autonomousCommand;
+  private Optional<Command> autonomousCommand;
 
   private RobotContainer robotContainer;
 
@@ -67,8 +67,7 @@ public class Robot extends TimedRobot {
     autonomousCommand = robotContainer.getAutonomousCommand();
 
     // Schedule the autonomous command
-    Optional.ofNullable(autonomousCommand)
-      .ifPresent((command) -> command.schedule());
+    autonomousCommand.ifPresent((command) -> command.schedule());
   }
 
   /** This function is called periodically during autonomous. */
@@ -78,8 +77,7 @@ public class Robot extends TimedRobot {
   @Override
   public void teleopInit() {
     // Cancel the autonomous command when teleop starts running.
-    Optional.ofNullable(autonomousCommand)
-      .ifPresent((command) -> command.cancel());
+    autonomousCommand.ifPresent((command) -> command.cancel());
   }
 
   /** This function is called periodically during operator control. */

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,6 +4,8 @@
 
 package frc.robot;
 
+import java.util.Optional;
+
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -64,10 +66,9 @@ public class Robot extends TimedRobot {
   public void autonomousInit() {
     autonomousCommand = robotContainer.getAutonomousCommand();
 
-    // schedule the autonomous command (example)
-    if (autonomousCommand != null) {
-      autonomousCommand.schedule();
-    }
+    // Schedule the autonomous command
+    Optional.ofNullable(autonomousCommand)
+      .ifPresent((command) -> command.schedule());
   }
 
   /** This function is called periodically during autonomous. */
@@ -76,13 +77,9 @@ public class Robot extends TimedRobot {
 
   @Override
   public void teleopInit() {
-    // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
-    // continue until interrupted by another command, remove
-    // this line or comment it out.
-    if (autonomousCommand != null) {
-      autonomousCommand.cancel();
-    }
+    // Cancel the autonomous command when teleop starts running.
+    Optional.ofNullable(autonomousCommand)
+      .ifPresent((command) -> command.cancel());
   }
 
   /** This function is called periodically during operator control. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -5,6 +5,8 @@
 package frc.robot;
 
 import java.io.IOException;
+import java.util.Optional;
+
 import com.pathplanner.lib.auto.AutoBuilder;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
@@ -47,8 +49,8 @@ public class RobotContainer {
     
   }
 
-  public Command getAutonomousCommand() {
-    return autoChooser.getSelected();
+  public Optional<Command> getAutonomousCommand() {
+    return Optional.ofNullable(autoChooser.getSelected());
   }
   
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -50,6 +50,7 @@ public class RobotContainer {
   }
 
   public Optional<Command> getAutonomousCommand() {
+    // Fetch the selected autonomous command from the dashoard and put it in an Optional
     return Optional.ofNullable(autoChooser.getSelected());
   }
   


### PR DESCRIPTION
Changes the selected autonomous command to be an `Optional`.
`Optional` has a lot of useful utility methods that simplify having to check if an object is `null`.
[Javadocs for Optional](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Optional.html)