### PR TITLE
ControlInputs + DriveSubsystem Simplification

### DIFF
--- a/src/main/java/frc/robot/ControlInputs.java
+++ b/src/main/java/frc/robot/ControlInputs.java
@@ -2,49 +2,52 @@ package frc.robot;
 
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.Joystick;
 
 public class ControlInputs {
-    //Joysticks IDs
-    private final int driveStickDeviceId = 0;
-    private final int componentsBoardLeftId = 1;
-    private final int componentsBoardRightId = 2;
+    // Singleton Instance
+    private static ControlInputs instance;
 
-    //Max Input
-    private final double driveStickMaxMovement = 0.8;
-    private final double driveStickMaxRotation = 0.5;
+    // Joysticks IDs
+    private final XboxController driveStick = new XboxController(0);
+    private final Joystick componentsBoardLeft = new Joystick(1);
+    private final Joystick componentsBoardRight = new Joystick(2);
 
-    //Buttons IDs
-        //Components Board Right
+    public DriveStickState getDriveStick() {
+        /**
+         * 
+         */
+        // Multipliers for the drive stick axes
+        final double driveStickLinearMultiplier = 0.8;
+        final double driveStickRotationMultiplier = 0.5;
 
-        //Components Board Left
-
-    //Joystick Definitions
-    private final XboxController driveStick = new XboxController(driveStickDeviceId);
-    private final Joystick componentsBoardLeft = new Joystick(componentsBoardLeftId);
-    private final Joystick componentsBoardRight = new Joystick(componentsBoardRightId);
-
-    //Variable Defintions
-    public double driveStickX = 0.0;
-    public double driveStickY = 0.0;
-    public double driveStickZrotation = 0.0;
-
-    //Reading the controls
-    public final void readControls() {
-        //Drivestick
-        driveStickX = ( driveStick.getLeftX() * Math.abs(driveStick.getLeftX()) ) * driveStickMaxMovement;
-        driveStickY = ( driveStick.getLeftY() * Math.abs(driveStick.getLeftY()) ) * driveStickMaxMovement;
-        driveStickZrotation = ( driveStick.getRightX() * Math.abs(driveStick.getRightX()) ) * driveStickMaxRotation;
-        //Components Board Right
-        
-        //Components Board Left
-       
-        //Drive Controller Climb
-       
+        // Get joystick values
+        var x = ( driveStick.getLeftX() * Math.abs(driveStick.getLeftX()) ) * driveStickLinearMultiplier;
+        var y = ( driveStick.getLeftY() * Math.abs(driveStick.getLeftY()) ) * driveStickLinearMultiplier;
+        var theta = ( driveStick.getRightX() * Math.abs(driveStick.getRightX()) ) * driveStickRotationMultiplier;
+        // Compose the seperate components into a state record
+        return new DriveStickState(x, y, theta);
     }
 
-    //For later
+    // For later
     public final void setRumble(double value) {
         driveStick.setRumble(RumbleType.kBothRumble, value);
     }
+
+    /**
+     * Returns the ControlInputs instance.
+     *
+     * @return the instance
+     */
+    public static synchronized ControlInputs getInstance() {
+        if (instance == null) {
+            instance = new ControlInputs();
+        }
+        return instance;
+    }
+
+    public static record DriveStickState(double x,double y,double theta) {}
 }

--- a/src/main/java/frc/robot/ControlInputs.java
+++ b/src/main/java/frc/robot/ControlInputs.java
@@ -19,17 +19,14 @@ public class ControlInputs {
     public static record DriveStickState(double x,double y,double rotation) {}
 
     public DriveStickState getDriveStick() {
-        /**
-         * 
-         */
         // Multipliers for the drive stick axes
         final double driveStickLinearMultiplier = 0.8;
         final double driveStickRotationMultiplier = 0.5;
 
         // Get joystick values
-        var x = ( driveStick.getLeftX() * Math.abs(driveStick.getLeftX()) ) * driveStickLinearMultiplier;
-        var y = ( driveStick.getLeftY() * Math.abs(driveStick.getLeftY()) ) * driveStickLinearMultiplier;
-        var rotation = ( driveStick.getRightX() * Math.abs(driveStick.getRightX()) ) * driveStickRotationMultiplier;
+        var x = ( driveStick.getLeftX() * Math.abs( driveStick.getLeftX()) ) * driveStickLinearMultiplier;
+        var y = ( driveStick.getLeftY() * Math.abs( driveStick.getLeftY()) ) * driveStickLinearMultiplier;
+        var rotation = ( driveStick.getRightX() * Math.abs( driveStick.getRightX()) ) * driveStickRotationMultiplier;
         // Compose the seperate components into a state record
         return new DriveStickState(x, y, rotation);
     }

--- a/src/main/java/frc/robot/ControlInputs.java
+++ b/src/main/java/frc/robot/ControlInputs.java
@@ -2,9 +2,6 @@ package frc.robot;
 
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Transform2d;
-import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.Joystick;
 
 public class ControlInputs {

--- a/src/main/java/frc/robot/ControlInputs.java
+++ b/src/main/java/frc/robot/ControlInputs.java
@@ -5,9 +5,6 @@ import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 import edu.wpi.first.wpilibj.Joystick;
 
 public class ControlInputs {
-    // Singleton Instance
-    private static ControlInputs instance;
-
     // Joysticks
     private final XboxController driveStick = new XboxController(0);
     private final Joystick componentsBoardLeft = new Joystick(1);
@@ -34,17 +31,5 @@ public class ControlInputs {
     // For later
     public final void setRumble(double value) {
         driveStick.setRumble(RumbleType.kBothRumble, value);
-    }
-
-    /**
-     * Returns the ControlInputs instance.
-     *
-     * @return the instance
-     */
-    public static synchronized ControlInputs getInstance() {
-        if (instance == null) {
-            instance = new ControlInputs();
-        }
-        return instance;
     }
 }

--- a/src/main/java/frc/robot/ControlInputs.java
+++ b/src/main/java/frc/robot/ControlInputs.java
@@ -8,11 +8,14 @@ public class ControlInputs {
     // Singleton Instance
     private static ControlInputs instance;
 
-    // Joysticks IDs
+    // Joysticks
     private final XboxController driveStick = new XboxController(0);
     private final Joystick componentsBoardLeft = new Joystick(1);
     private final Joystick componentsBoardRight = new Joystick(2);
 
+    /**
+     * Holds unitless multipliers on linear and angular velocity derived from joystick input.
+     */
     public static record DriveStickState(double x,double y,double rotation) {}
 
     public DriveStickState getDriveStick() {
@@ -20,7 +23,7 @@ public class ControlInputs {
         final double driveStickLinearMultiplier = 0.8;
         final double driveStickRotationMultiplier = 0.5;
 
-        // Get joystick values
+        // Derive joystick values. Inputs are squared to make precice control at low speeds easier
         var x = ( driveStick.getLeftX() * Math.abs( driveStick.getLeftX()) ) * driveStickLinearMultiplier;
         var y = ( driveStick.getLeftY() * Math.abs( driveStick.getLeftY()) ) * driveStickLinearMultiplier;
         var rotation = ( driveStick.getRightX() * Math.abs( driveStick.getRightX()) ) * driveStickRotationMultiplier;

--- a/src/main/java/frc/robot/ControlInputs.java
+++ b/src/main/java/frc/robot/ControlInputs.java
@@ -16,6 +16,8 @@ public class ControlInputs {
     private final Joystick componentsBoardLeft = new Joystick(1);
     private final Joystick componentsBoardRight = new Joystick(2);
 
+    public static record DriveStickState(double x,double y,double rotation) {}
+
     public DriveStickState getDriveStick() {
         /**
          * 
@@ -27,9 +29,9 @@ public class ControlInputs {
         // Get joystick values
         var x = ( driveStick.getLeftX() * Math.abs(driveStick.getLeftX()) ) * driveStickLinearMultiplier;
         var y = ( driveStick.getLeftY() * Math.abs(driveStick.getLeftY()) ) * driveStickLinearMultiplier;
-        var theta = ( driveStick.getRightX() * Math.abs(driveStick.getRightX()) ) * driveStickRotationMultiplier;
+        var rotation = ( driveStick.getRightX() * Math.abs(driveStick.getRightX()) ) * driveStickRotationMultiplier;
         // Compose the seperate components into a state record
-        return new DriveStickState(x, y, theta);
+        return new DriveStickState(x, y, rotation);
     }
 
     // For later
@@ -48,6 +50,4 @@ public class ControlInputs {
         }
         return instance;
     }
-
-    public static record DriveStickState(double x,double y,double theta) {}
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -28,7 +28,7 @@ public class Robot extends TimedRobot {
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     try {
-        robotContainer = new RobotContainer();
+      robotContainer = new RobotContainer();
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -29,7 +29,7 @@ public class RobotContainer {
    */
   public RobotContainer() throws IOException, Exception{
     swerveDriveTrain = new DriveSubsystem();
-    swerveDriveTrain.setDefaultCommand(swerveDriveTrain.driveFieldCentric());
+    swerveDriveTrain.setDefaultCommand(swerveDriveTrain.teleopDriveFieldCentric());
     autoChooser = AutoBuilder.buildAutoChooser();
     SmartDashboard.putData("Auto Chooser", autoChooser);
   }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -7,10 +7,6 @@ package frc.robot;
 import java.io.IOException;
 import com.pathplanner.lib.auto.AutoBuilder;
 
-import edu.wpi.first.math.Matrix;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Transform2d;
-import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -6,8 +6,11 @@ package frc.robot;
 
 import java.io.IOException;
 import com.pathplanner.lib.auto.AutoBuilder;
+
+import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -20,7 +23,6 @@ import frc.robot.subsystems.DriveSubsystem;
  */
 public class RobotContainer {
   private final DriveSubsystem swerveDriveTrain;
-  private final ControlInputs controlInputs = new ControlInputs();
   private final SensorInputs sensorInputs = new SensorInputs();
   private final SendableChooser<Command> autoChooser;
   private Command autoSelected;
@@ -31,15 +33,12 @@ public class RobotContainer {
    */
   public RobotContainer() throws IOException, Exception{
     swerveDriveTrain = new DriveSubsystem();
-    swerveDriveTrain.setDefaultCommand(swerveDriveTrain.driveFieldCentric(() -> {
-      return new Transform2d(-controlInputs.driveStickY, -controlInputs.driveStickX, Rotation2d.fromRadians(-controlInputs.driveStickZrotation));
-    }));
+    swerveDriveTrain.setDefaultCommand(swerveDriveTrain.driveFieldCentric());
     autoChooser = AutoBuilder.buildAutoChooser();
     SmartDashboard.putData("Auto Chooser", autoChooser);
   }
 
   public void robotPeriodic() {
-    controlInputs.readControls();
     sensorInputs.readSensors();
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -11,6 +11,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.subsystems.DriveSubsystem.DriveOrientation;
 
 /**
  * The methods in this class are called automatically corresponding to each mode, as described in
@@ -29,7 +30,7 @@ public class RobotContainer {
    */
   public RobotContainer() throws IOException, Exception{
     swerveDriveTrain = new DriveSubsystem();
-    swerveDriveTrain.setDefaultCommand(swerveDriveTrain.teleopDriveFieldCentric());
+    swerveDriveTrain.setDefaultCommand(swerveDriveTrain.teleopDrive(DriveOrientation.FIELD_CENTRIC));
     autoChooser = AutoBuilder.buildAutoChooser();
     SmartDashboard.putData("Auto Chooser", autoChooser);
   }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -19,6 +19,7 @@ import frc.robot.subsystems.DriveSubsystem.DriveOrientation;
  * this project, you must also update the Main.java file in the project.
  */
 public class RobotContainer {
+  private final ControlInputs controlInputs = new ControlInputs();
   private final DriveSubsystem swerveDriveTrain;
   private final SensorInputs sensorInputs = new SensorInputs();
   private final SendableChooser<Command> autoChooser;
@@ -30,7 +31,10 @@ public class RobotContainer {
    */
   public RobotContainer() throws IOException, Exception{
     swerveDriveTrain = new DriveSubsystem();
-    swerveDriveTrain.setDefaultCommand(swerveDriveTrain.teleopDrive(DriveOrientation.FIELD_CENTRIC));
+    swerveDriveTrain.setDefaultCommand(swerveDriveTrain.teleopDrive(
+      () -> controlInputs.getDriveStick(),
+      DriveOrientation.FIELD_CENTRIC
+    ));
     autoChooser = AutoBuilder.buildAutoChooser();
     SmartDashboard.putData("Auto Chooser", autoChooser);
   }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -69,7 +69,7 @@ public class DriveSubsystem extends SubsystemBase {
    * @param transform_supplier  Function that returns a translation and rotation
    * @return Drive command.
    */
-  public Command driveFieldCentric() {
+  public Command teleopDriveFieldCentric() {
     return this.run(() -> {
       var input = ControlInputs.getInstance().getDriveStick();
       ChassisSpeeds chassisSpeeds = new ChassisSpeeds();
@@ -87,7 +87,7 @@ public class DriveSubsystem extends SubsystemBase {
    * @param transform_supplier  Function that returns a translation and rotation
    * @return Drive command.
    */
-  public Command driveRobotCentric() {
+  public Command teleopDriveRobotCentric() {
     return this.run(() -> {
       var input = ControlInputs.getInstance().getDriveStick();
       ChassisSpeeds chassisSpeeds = new ChassisSpeeds();

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -61,39 +61,31 @@ public class DriveSubsystem extends SubsystemBase {
     );
   }
   
-  /**
-   * Command to drive the robot from joystick input using translative values
-   * and heading as angular velocity. Should be used as a default command.
-   *
-   * @param transform_supplier  Function that returns a translation and rotation
-   * @return Drive command.
-   */
-  public Command teleopDriveFieldCentric() {
-    return this.run(() -> {
-      var input = ControlInputs.getInstance().getDriveStick();
-      ChassisSpeeds chassisSpeeds = new ChassisSpeeds();
-      chassisSpeeds.vxMetersPerSecond = -input.y() * swerveDrive.getMaximumChassisVelocity();
-      chassisSpeeds.vyMetersPerSecond = -input.x() * swerveDrive.getMaximumChassisVelocity();
-      chassisSpeeds.omegaRadiansPerSecond = -input.rotation() * swerveDrive.getMaximumChassisAngularVelocity();
-      swerveDrive.driveFieldOriented(chassisSpeeds);
-    });
+  public static enum DriveOrientation {
+    /** Forwards is a constant direction. */
+    FIELD_CENTRIC,
+    /** Forwards is based on the robot's direction. */
+    ROBOT_CENTRIC,
   }
 
   /**
    * Command to drive the robot from joystick input using translative values
    * and heading as angular velocity. Should be used as a default command.
    *
-   * @param transform_supplier  Function that returns a translation and rotation
+   * @param orientation The type of orientation to use.
    * @return Drive command.
    */
-  public Command teleopDriveRobotCentric() {
+  public Command teleopDrive(DriveOrientation orientation) {
     return this.run(() -> {
       var input = ControlInputs.getInstance().getDriveStick();
       ChassisSpeeds chassisSpeeds = new ChassisSpeeds();
       chassisSpeeds.vxMetersPerSecond = -input.y() * swerveDrive.getMaximumChassisVelocity();
       chassisSpeeds.vyMetersPerSecond = -input.x() * swerveDrive.getMaximumChassisVelocity();
       chassisSpeeds.omegaRadiansPerSecond = -input.rotation() * swerveDrive.getMaximumChassisAngularVelocity();
-      swerveDrive.drive(chassisSpeeds);
+      switch(orientation) {
+        case FIELD_CENTRIC: swerveDrive.driveFieldOriented(chassisSpeeds);
+        case ROBOT_CENTRIC: swerveDrive.drive(chassisSpeeds);
+      }
     });
   }
 

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -4,6 +4,9 @@ import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.config.PIDConstants;
 import com.pathplanner.lib.config.RobotConfig;
 import com.pathplanner.lib.controllers.PPHolonomicDriveController;
+
+import static edu.wpi.first.units.Units.MetersPerSecond;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.function.Supplier;
@@ -14,9 +17,12 @@ import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.ControlInputs;
 import swervelib.parser.SwerveParser;
 import swervelib.SwerveDrive;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.LinearVelocity;
 import swervelib.telemetry.SwerveDriveTelemetry;
 import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -31,9 +37,9 @@ public class DriveSubsystem extends SubsystemBase {
     RobotConfig config;
 
     //In Meters Per Second
-    double maximumSpeed = 4.35864;
+    LinearVelocity maximumSpeed = MetersPerSecond.of(4.35864);
     File swerveJsonDirectory = new File(Filesystem.getDeployDirectory(), "swerve");
-    swerveDrive = new SwerveParser(swerveJsonDirectory).createSwerveDrive(maximumSpeed);
+    swerveDrive = new SwerveParser(swerveJsonDirectory).createSwerveDrive(maximumSpeed.magnitude());
     config = RobotConfig.fromGUISettings();
     
     AutoBuilder.configure(
@@ -66,15 +72,13 @@ public class DriveSubsystem extends SubsystemBase {
    * @param transform_supplier  Function that returns a translation and rotation
    * @return Drive command.
    */
-  public Command driveFieldCentric(Supplier<Transform2d> transform_supplier) {
+  public Command driveFieldCentric() {
     return this.run(() -> {
-      var transform = transform_supplier.get();
-      var translation = transform.getTranslation();
-      var rotation = transform.getRotation();
+      var input = ControlInputs.getInstance().getDriveStick();
       ChassisSpeeds chassisSpeeds = new ChassisSpeeds();
-      chassisSpeeds.vxMetersPerSecond = translation.getX() * swerveDrive.getMaximumChassisVelocity();
-      chassisSpeeds.vyMetersPerSecond = translation.getY() * swerveDrive.getMaximumChassisVelocity();
-      chassisSpeeds.omegaRadiansPerSecond = rotation.getRadians() * swerveDrive.getMaximumChassisAngularVelocity();
+      chassisSpeeds.vxMetersPerSecond = -input.y() * swerveDrive.getMaximumChassisVelocity();
+      chassisSpeeds.vyMetersPerSecond = -input.x() * swerveDrive.getMaximumChassisVelocity();
+      chassisSpeeds.omegaRadiansPerSecond = -input.theta() * swerveDrive.getMaximumChassisAngularVelocity();
       swerveDrive.driveFieldOriented(chassisSpeeds);
     });
   }
@@ -86,15 +90,13 @@ public class DriveSubsystem extends SubsystemBase {
    * @param transform_supplier  Function that returns a translation and rotation
    * @return Drive command.
    */
-  public Command driveRobotCentric(Supplier<Transform2d> transform_supplier) {
+  public Command driveRobotCentric() {
     return this.run(() -> {
-      var transform = transform_supplier.get();
-      var translation = transform.getTranslation();
-      var rotation = transform.getRotation();
+      var input = ControlInputs.getInstance().getDriveStick();
       ChassisSpeeds chassisSpeeds = new ChassisSpeeds();
-      chassisSpeeds.vxMetersPerSecond = translation.getX() * swerveDrive.getMaximumChassisVelocity();
-      chassisSpeeds.vyMetersPerSecond = translation.getY() * swerveDrive.getMaximumChassisVelocity();
-      chassisSpeeds.omegaRadiansPerSecond = rotation.getRadians() * swerveDrive.getMaximumChassisAngularVelocity();
+      chassisSpeeds.vxMetersPerSecond = -input.y() * swerveDrive.getMaximumChassisVelocity();
+      chassisSpeeds.vyMetersPerSecond = -input.x() * swerveDrive.getMaximumChassisVelocity();
+      chassisSpeeds.omegaRadiansPerSecond = -input.theta() * swerveDrive.getMaximumChassisAngularVelocity();
       swerveDrive.drive(chassisSpeeds);
     });
   }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -17,7 +17,6 @@ import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.ControlInputs;
 import frc.robot.ControlInputs.DriveStickState;
 import swervelib.parser.SwerveParser;
 import swervelib.SwerveDrive;

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -9,6 +9,7 @@ import static edu.wpi.first.units.Units.MetersPerSecond;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.function.Supplier;
 
 import org.json.simple.parser.ParseException;
 import edu.wpi.first.wpilibj.DriverStation;
@@ -17,6 +18,7 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.ControlInputs;
+import frc.robot.ControlInputs.DriveStickState;
 import swervelib.parser.SwerveParser;
 import swervelib.SwerveDrive;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
@@ -75,9 +77,9 @@ public class DriveSubsystem extends SubsystemBase {
    * @param orientation The type of orientation to use.
    * @return Drive command.
    */
-  public Command teleopDrive(DriveOrientation orientation) {
+  public Command teleopDrive(Supplier<DriveStickState> controls, DriveOrientation orientation) {
     return this.run(() -> {
-      var input = ControlInputs.getInstance().getDriveStick();
+      var input = controls.get();
       ChassisSpeeds chassisSpeeds = new ChassisSpeeds();
       chassisSpeeds.vxMetersPerSecond = -input.y() * swerveDrive.getMaximumChassisVelocity();
       chassisSpeeds.vyMetersPerSecond = -input.x() * swerveDrive.getMaximumChassisVelocity();

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -63,8 +63,8 @@ public class DriveSubsystem extends SubsystemBase {
   }
   
   /**
-   * Command to drive the robot using translative values and heading as angular
-   * velocity.
+   * Command to drive the robot from joystick input using translative values
+   * and heading as angular velocity. Should be used as a default command.
    *
    * @param transform_supplier  Function that returns a translation and rotation
    * @return Drive command.
@@ -81,8 +81,8 @@ public class DriveSubsystem extends SubsystemBase {
   }
 
   /**
-   * Command to drive the robot using translative values and heading as angular
-   * velocity.
+   * Command to drive the robot from joystick input using translative values
+   * and heading as angular velocity. Should be used as a default command.
    *
    * @param transform_supplier  Function that returns a translation and rotation
    * @return Drive command.

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -9,7 +9,6 @@ import static edu.wpi.first.units.Units.MetersPerSecond;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.function.Supplier;
 
 import org.json.simple.parser.ParseException;
 import edu.wpi.first.wpilibj.DriverStation;
@@ -21,12 +20,10 @@ import frc.robot.ControlInputs;
 import swervelib.parser.SwerveParser;
 import swervelib.SwerveDrive;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearVelocity;
 import swervelib.telemetry.SwerveDriveTelemetry;
 import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Transform2d;
 
 public class DriveSubsystem extends SubsystemBase {
   SwerveDrive swerveDrive;

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -33,7 +33,6 @@ public class DriveSubsystem extends SubsystemBase {
 
     RobotConfig config;
 
-    //In Meters Per Second
     LinearVelocity maximumSpeed = MetersPerSecond.of(4.35864);
     File swerveJsonDirectory = new File(Filesystem.getDeployDirectory(), "swerve");
     swerveDrive = new SwerveParser(swerveJsonDirectory).createSwerveDrive(maximumSpeed.magnitude());

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -78,7 +78,7 @@ public class DriveSubsystem extends SubsystemBase {
       ChassisSpeeds chassisSpeeds = new ChassisSpeeds();
       chassisSpeeds.vxMetersPerSecond = -input.y() * swerveDrive.getMaximumChassisVelocity();
       chassisSpeeds.vyMetersPerSecond = -input.x() * swerveDrive.getMaximumChassisVelocity();
-      chassisSpeeds.omegaRadiansPerSecond = -input.theta() * swerveDrive.getMaximumChassisAngularVelocity();
+      chassisSpeeds.omegaRadiansPerSecond = -input.rotation() * swerveDrive.getMaximumChassisAngularVelocity();
       swerveDrive.driveFieldOriented(chassisSpeeds);
     });
   }
@@ -96,7 +96,7 @@ public class DriveSubsystem extends SubsystemBase {
       ChassisSpeeds chassisSpeeds = new ChassisSpeeds();
       chassisSpeeds.vxMetersPerSecond = -input.y() * swerveDrive.getMaximumChassisVelocity();
       chassisSpeeds.vyMetersPerSecond = -input.x() * swerveDrive.getMaximumChassisVelocity();
-      chassisSpeeds.omegaRadiansPerSecond = -input.theta() * swerveDrive.getMaximumChassisAngularVelocity();
+      chassisSpeeds.omegaRadiansPerSecond = -input.rotation() * swerveDrive.getMaximumChassisAngularVelocity();
       swerveDrive.drive(chassisSpeeds);
     });
   }


### PR DESCRIPTION
Changes in `ControlInputs`:
- No longer stores state, so that update order is no longer a relevant problem.
- Because of the previous point, the (x,y,rotation) values used in the drive train are now packaged together in a separate record class (currently named `DriveStickStates`).
- Joystick IDs have been merged with the instantiation of the actual joysticks.

Changes in `DriveSubsystem`:
- Replaced the field-centric and robot-centric drive methods with one method `driveTeleop` to remove duplicate code. Orientation is now handled by a `RobotOrientation` enum with two values (`FIELD_CENTRIC`, `ROBOT_CENTRIC`).
- Additionally `driveTeleop` now takes a function returning `DriveStickStates` as a parameter.
- Instead of a comment describing that the units are m/s, the `maximumSpeed` constant now uses WPILib's unit libraries.