### PR TITLE
Small Change to Maximum Speed Units

### DIFF
--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -36,7 +36,7 @@ public class DriveSubsystem extends SubsystemBase {
 
     LinearVelocity maximumSpeed = MetersPerSecond.of(4.35864);
     File swerveJsonDirectory = new File(Filesystem.getDeployDirectory(), "swerve");
-    swerveDrive = new SwerveParser(swerveJsonDirectory).createSwerveDrive(maximumSpeed.magnitude());
+    swerveDrive = new SwerveParser(swerveJsonDirectory).createSwerveDrive(maximumSpeed.in(MetersPerSecond));
     config = RobotConfig.fromGUISettings();
     
     AutoBuilder.configure(


### PR DESCRIPTION
An extremely small change, since I found the method I was actually looking to use in the first place.
- `maximumSpeed.magnitude()` is now `maximumSpeed.in(MetersPerSecond)` for clarity.