### PR TITLE
Update WPILib Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2025.1.1"
+    id "edu.wpi.first.GradleRIO" version "2025.2.1"
 }
 
 java {


### PR DESCRIPTION
Update WPILib to 2025.2.1, which adds AprilTag information for the 2025 field.